### PR TITLE
Fix ResourceWarning: unclosed file

### DIFF
--- a/yq/__init__.py
+++ b/yq/__init__.py
@@ -67,6 +67,7 @@ def main(args=None):
             json.dump(yaml.load(input_stream, Loader=OrderedLoader), jq.stdin)
             jq.stdin.close()
             jq.wait()
+        input_stream.close()
         exit(jq.returncode)
     except Exception as e:
         parser.exit("yq: Error while running jq: {}: {}.".format(type(e).__name__, e))


### PR DESCRIPTION
Fix the following ResourceWarning which is displayed with the
variable setting PYTHONWARNINGS=d exported:
```
sys:1: ResourceWarning: unclosed file <_io.TextIOWrapper name='foo.yaml' mode='r' encoding='UTF-8'>
```