### PR TITLE
Fix issue with yq -s generating incorrect result

### DIFF
--- a/yq/__init__.py
+++ b/yq/__init__.py
@@ -84,6 +84,8 @@ def main(args=None):
             json_decoder = json.JSONDecoder(object_pairs_hook=OrderedDict)
             yaml.dump_all(decode_docs(jq_out, json_decoder), stream=sys.stdout, Dumper=OrderedDumper, width=args.width,
                           allow_unicode=True, default_flow_style=False)
+        for input_stream in input_streams:
+            input_stream.close()
         exit(jq.returncode)
     except Exception as e:
         parser.exit("yq: Error running jq: {}: {}.".format(type(e).__name__, e))

--- a/yq/__init__.py
+++ b/yq/__init__.py
@@ -78,18 +78,12 @@ def main(args=None):
         input_docs = []
         for input_stream in input_streams:
             input_docs.extend(yaml.load_all(input_stream, Loader=OrderedLoader))
+        input_payload = "\n".join(json.dumps(doc, cls=JSONDateTimeEncoder) for doc in input_docs)
+        jq_out, jq_err = jq.communicate(input_payload)
         if args.yaml_output:
-            input_payload = "\n".join(json.dumps(doc, cls=JSONDateTimeEncoder) for doc in input_docs)
-            jq_out, jq_err = jq.communicate(input_payload)
             json_decoder = json.JSONDecoder(object_pairs_hook=OrderedDict)
             yaml.dump_all(decode_docs(jq_out, json_decoder), stream=sys.stdout, Dumper=OrderedDumper, width=args.width,
                           allow_unicode=True, default_flow_style=False)
-        else:
-            for doc in input_docs:
-                json.dump(doc, jq.stdin, cls=JSONDateTimeEncoder)
-            jq.stdin.close()
-            jq.wait()
-        input_stream.close()
         exit(jq.returncode)
     except Exception as e:
         parser.exit("yq: Error running jq: {}: {}.".format(type(e).__name__, e))


### PR DESCRIPTION
Reproduction sequence of issue generating bug (jq version 1.5):
* a.yml
```
a: 2
b:
  c: 3
```
* b.yml
```
d: 3
b:
 e: 4
```
* yq -y -s (Works correctly)
```
bubbleattic:~/workspace (fixjsonoutbug) $ yq -s -y '.[0] * .[1]' ~/a.json ~/b.json                                                                                                                                                                                         
b:
  c: 3
  e: 4
a: 2
d: 3
```
* yq -s (Does not work)
```
bubbleattic:~/workspace (master) $ yq -s '.[0] * .[1]' ~/a.json ~/b.json 
jq: error (at <stdin>:0): object ({"b":{"c":3...) and null (null) cannot be multiplied
jq: error (at <stdin>:0): Cannot index object with number
```


The reason for this is because yq -y passes multiple json documents to jq on multiple lines
```
{...JSON1...}
{...JSON2...}
```
Where as yq with no "-y" passes multiple json documents on single line with no newline
```
{...JSON1...}{...JSON2...}
```

And there is a bug in jq 1.5 where doesn't parse correctly if multiple jsons on one line https://github.com/stedolan/jq/issues/1486

If switch to branch in pull request
```
bubbleattic:~/workspace (fixjsonoutbug) $ yq -s '.[0] * .[1]' ~/a.json ~/b.json 
{
  "b": {
    "c": 3,
    "e": 4
  },
  "a": 2,
  "d": 3
}
```

I feel changing code so both "yq" and "yq -y" send exact same input to "jq" is correct solution since 
1) There is no reason for them to generate different inputs to jq
2) Even if jq didn't have issue parsing multiple json documents on single line, having json documents on multiple lines still makes more sense