### PR TITLE
Fix dates (without times) and times (without dates)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     long_description=open("README.rst").read(),
     install_requires=[
         "setuptools",
-        "PyYAML >= 3.11"
+        "ruamel.yaml >= 0.15.35"
     ],
     tests_require=tests_require,
     extras_require={"test": tests_require},

--- a/test/test.py
+++ b/test/test.py
@@ -57,5 +57,8 @@ class TestYq(unittest.TestCase):
         self.assertEqual(self.run_yq("- 2016-12-20T22:07:36Z\n", ["."]), "")
         self.assertEqual(self.run_yq("- 2016-12-20T22:07:36Z\n", ["-y", "."]), "- '2016-12-20T22:07:36'\n")
 
+        self.assertEqual(self.run_yq("2016-12-20", ["."]), "")
+        self.assertEqual(self.run_yq("2016-12-20", ["-y", "."]), "'2016-12-20'\n")
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test.py
+++ b/test/test.py
@@ -60,5 +60,8 @@ class TestYq(unittest.TestCase):
         self.assertEqual(self.run_yq("2016-12-20", ["."]), "")
         self.assertEqual(self.run_yq("2016-12-20", ["-y", "."]), "'2016-12-20'\n")
 
+        self.assertEqual(self.run_yq("11:12:13", ["."]), "")
+        self.assertEqual(self.run_yq("11:12:13", ["-y", "."]), "'11:12:13'\n")
+
 if __name__ == '__main__':
     unittest.main()

--- a/yq/__init__.py
+++ b/yq/__init__.py
@@ -19,7 +19,7 @@ class Parser(argparse.ArgumentParser):
         print("\n".join(["usage: yq [options] <jq filter> [YAML file...]"] + yq_help[1:] + [""]))
         try:
             subprocess.check_call(["jq", "--help"])
-        except:
+        except Exception:
             pass
 
 class OrderedLoader(yaml.SafeLoader):

--- a/yq/__init__.py
+++ b/yq/__init__.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os, sys, argparse, subprocess, json
 from collections import OrderedDict
 from datetime import datetime, date
-import yaml
+from ruamel import yaml
 from .version import __version__
 
 class Parser(argparse.ArgumentParser):

--- a/yq/__init__.py
+++ b/yq/__init__.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os, sys, argparse, subprocess, json
 from collections import OrderedDict
-from datetime import datetime
+from datetime import datetime, date
 import yaml
 from .version import __version__
 
@@ -30,7 +30,7 @@ class OrderedDumper(yaml.SafeDumper):
 
 class JSONDateTimeEncoder(json.JSONEncoder):
     def default(self, o):
-        if isinstance(o, datetime):
+        if isinstance(o, (datetime, date)):
             return o.isoformat()
         return json.JSONEncoder.default(self, o)
 


### PR DESCRIPTION
I found two separate but related problems, the first is a date without a time (fixed by adding `datetime.date` to the `JSONDateTimeEncoder`; the second a time without a date, which yaml refers to as a sexagesimal. YAML 1.1 specifies that these parse as base 60 integers, and can't easily be round-tripped. I fixed that by switching to an api-compatible yaml loader that supports yaml 1.2, which [eliminates sexagesimals](http://yaml.readthedocs.io/en/latest/pyyaml.html#defaulting-to-yaml-1-2-support) among other things.