### PR TITLE
Translate unknown tags in YAML

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -41,6 +41,9 @@ class TestYq(unittest.TestCase):
         err = 'yq: Error running jq: ScannerError: while scanning for the next token\nfound character \'%\' that cannot start any token\n  in "<file>", line 1, column 3.'
         self.run_yq("- %", ["."], expect_exit_code=err)
 
+    def test_tags(self):
+        self.assertEqual(self.run_yq("!abc junk", ["-y", ".__yq_tag_abc"]), "junk\n...\n")
+
     def fd_path(self, fh):
         return "/dev/fd/{}".format(fh.fileno())
 

--- a/yq/__init__.py
+++ b/yq/__init__.py
@@ -57,7 +57,7 @@ def default_constructor(loader, tag_suffix, node):
         constructor = yaml.constructor.BaseConstructor.construct_mapping
     inner = constructor(loader, node)
     if tag_suffix:
-        return {'__yq_tag:{}'.format(tag_suffix): inner}
+        return {'__yq_tag_{}'.format(tag_suffix[1:]): inner}
     else:
         return inner
 

--- a/yq/__init__.py
+++ b/yq/__init__.py
@@ -11,6 +11,7 @@ import os, sys, argparse, subprocess, json
 from collections import OrderedDict
 from datetime import datetime, date, time
 import yaml
+import yaml.constructor
 from .version import __version__
 
 class Parser(argparse.ArgumentParser):
@@ -47,7 +48,21 @@ def decode_docs(jq_output, json_decoder):
         jq_output = jq_output[pos+1:]
         yield doc
 
+def default_constructor(loader, tag_suffix, node):
+    if isinstance(node, yaml.ScalarNode):
+        constructor = yaml.constructor.BaseConstructor.construct_scalar
+    elif isinstance(node, yaml.SequenceNode):
+        constructor = yaml.constructor.BaseConstructor.construct_sequence
+    elif isinstance(node, yaml.MappingNode):
+        constructor = yaml.constructor.BaseConstructor.construct_mapping
+    inner = constructor(loader, node)
+    if tag_suffix:
+        return {'__yq_tag:{}'.format(tag_suffix): inner}
+    else:
+        return inner
+
 OrderedLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, construct_mapping)
+OrderedLoader.add_multi_constructor('', default_constructor)
 OrderedDumper.add_representer(OrderedDict, represent_dict_order)
 
 parser = Parser(description=__doc__, formatter_class=argparse.RawTextHelpFormatter)


### PR DESCRIPTION
A lot of documents have tags (ex: cloudformation) which currently cause
yq to bomb out.  This translates the tags into objects with a single key
 equal to '__yq_tag_TAG' (which hopefully keeps it unique) with the key's value
 being the tagged value.

Pyyaml doesn't expose a way to do this nicely - it looks like it expects
you to process the whole subtree, so I had to copy a chunk of the
original code from the pyyaml constructor.py source.  I omitted some
code that was there to keep the pr small, but I think it was for
features not being used in yq.