### PR TITLE
Replace scripts in favor of entry-points.

### DIFF
--- a/scripts/xq
+++ b/scripts/xq
@@ -1,5 +1,0 @@
-#!/usr/bin/env python
-
-from yq import main
-
-main(input_format="xml")

--- a/scripts/yq
+++ b/scripts/yq
@@ -1,5 +1,0 @@
-#!/usr/bin/env python
-
-from yq import main
-
-main(input_format="yaml")

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,12 @@ setup(
     tests_require=tests_require,
     extras_require={"test": tests_require},
     packages=find_packages(exclude=["test"]),
-    scripts=glob.glob("scripts/*"),
     include_package_data=True,
+    entry_points = '''
+        [console_scripts]
+        yq=yq:main
+        xq=yq:xq_cli
+    ''',
     test_suite="test",
     classifiers=[
         "Intended Audience :: Developers",

--- a/yq/__init__.py
+++ b/yq/__init__.py
@@ -82,6 +82,9 @@ for arg in jq_arg_spec:
 parser.add_argument("jq_filter")
 parser.add_argument("files", nargs="*", type=argparse.FileType())
 
+def xq_cli():
+    main(input_format="xml")
+
 def main(args=None, input_format="yaml"):
     args, jq_args = parser.parse_known_args(args=args)
     for arg in jq_arg_spec:


### PR DESCRIPTION
- According to setup.py documentation[1], it is a 
    best practice to use entry-points instead of scripts, as 
    it is a cross-platform way to create "python-executables"

[1] - https://packaging.python.org/tutorials/distributing-packages/#scripts