### PR TITLE
jq colorizer compatibility, fix #71

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -119,6 +119,9 @@ class TestYq(unittest.TestCase):
             tf.seek(0)
             self.assertEqual(self.run_yq("", ["-y", ".xyz.foo", self.fd_path(tf)]), 'bar\n...\n')
 
+    def test_jq_colorize(self):
+        self.assertEqual(self.run_yq("{}", [".", "-C", "-y", "-C"]), '{}\n', 'issue #71')
+
     @unittest.expectedFailure
     def test_times(self):
         """

--- a/yq/__init__.py
+++ b/yq/__init__.py
@@ -154,6 +154,8 @@ def yq(input_streams=None, output_stream=None, input_format="yaml", output_forma
     if not exit_func:
         exit_func = sys.exit
     converting_output = True if output_format != "json" else False
+    if converting_output and '-C' in jq_args:
+        jq_args = [_ for _ in jq_args if _ != '-C']
 
     try:
         # Note: universal_newlines is just a way to induce subprocess to make stdin a text buffer and encode it for us


### PR DESCRIPTION
Fixed the case when colorization is asked on a non-JSON format (until now `yq -[t|y|x] -C . file.yml` would fail with `Error running jq: JSONDecodeError: Expecting value: line 1 column 1 (char 0).`