### PR TITLE
Ensure proper ordering of help messages

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -34,7 +34,7 @@ release:
 	    $${EDITOR:-emacs} $$TAG_MSG; \
 	    if [[ -f Changes.md ]]; then cat $$TAG_MSG <(echo) Changes.md | sponge Changes.md; git add Changes.md; fi; \
 	    if [[ -f Changes.rst ]]; then cat <(pandoc --from markdown --to rst $$TAG_MSG) <(echo) Changes.rst | sponge Changes.rst; git add Changes.rst; fi; \
-	    PYTHONUNBUFFERED=1 yq --help > docs/cli-doc.txt; git add docs/cli-doc.txt;
+	    yq --help > docs/cli-doc.txt; git add docs/cli-doc.txt;
 	    git commit -m ${TAG}; \
 	    git tag --sign --annotate --file $$TAG_MSG ${TAG}
 	git push --follow-tags

--- a/yq/parser.py
+++ b/yq/parser.py
@@ -12,6 +12,7 @@ class Parser(argparse.ArgumentParser):
     def print_help(self):
         yq_help = argparse.ArgumentParser.format_help(self).splitlines()
         print("\n".join(["usage: yq [options] <jq filter> [YAML file...]"] + yq_help[1:] + [""]))
+        sys.stdout.flush()
         try:
             subprocess.check_call(["jq", "--help"])
         except Exception:


### PR DESCRIPTION
What this fixes: Output of `yq --help` is different when stdout is a terminal (`yq`'s options followed by `jq`'s) and when it is a regular file or pipe (`jq` first, then `yq`).