### PR TITLE
Add support for xmltodict force_list definition for xq CLI

### DIFF
--- a/yq/__init__.py
+++ b/yq/__init__.py
@@ -130,7 +130,7 @@ def cli(args=None, input_format="yaml", program_name="yq"):
         yq(**yq_args)
 
 def yq(input_streams=None, output_stream=None, input_format="yaml", output_format="json",
-       program_name="yq", width=None, indentless_lists=False, xml_root=None, xml_dtd=False,
+       program_name="yq", width=None, indentless_lists=False, xml_root=None, xml_dtd=False, xml_force_list=frozenset(),
        explicit_start=False, explicit_end=False, jq_args=frozenset(), exit_func=None):
     if not input_streams:
         input_streams = [sys.stdin]
@@ -163,7 +163,8 @@ def yq(input_streams=None, output_stream=None, input_format="yaml", output_forma
                     input_docs.extend(yaml.load_all(input_stream, Loader=loader))
                 elif input_format == "xml":
                     import xmltodict
-                    input_docs.append(xmltodict.parse(input_stream.read(), disable_entities=True))
+                    input_docs.append(xmltodict.parse(input_stream.read(), disable_entities=True,
+                                                      force_list=xml_force_list))
                 elif input_format == "toml":
                     import toml
                     input_docs.append(toml.load(input_stream))
@@ -220,7 +221,8 @@ def yq(input_streams=None, output_stream=None, input_format="yaml", output_forma
             elif input_format == "xml":
                 import xmltodict
                 for input_stream in input_streams:
-                    json.dump(xmltodict.parse(input_stream.read(), disable_entities=True), jq.stdin)
+                    json.dump(xmltodict.parse(input_stream.read(), disable_entities=True,
+                                              force_list=xml_force_list), jq.stdin)
                     jq.stdin.write("\n")
             elif input_format == "toml":
                 import toml

--- a/yq/parser.py
+++ b/yq/parser.py
@@ -22,7 +22,8 @@ def get_parser(program_name, description):
     # By default suppress these help strings and only enable them in the specific programs.
     yaml_output_help, yaml_roundtrip_help, width_help, indentless_help = (argparse.SUPPRESS, argparse.SUPPRESS,
                                                                           argparse.SUPPRESS, argparse.SUPPRESS)
-    xml_output_help, xml_dtd_help, xml_root_help = argparse.SUPPRESS, argparse.SUPPRESS, argparse.SUPPRESS
+    xml_output_help, xml_dtd_help, xml_root_help, xml_force_list_help = (argparse.SUPPRESS, argparse.SUPPRESS,
+                                                                         argparse.SUPPRESS, argparse.SUPPRESS)
     toml_output_help = argparse.SUPPRESS
 
     if program_name == "yq":
@@ -40,6 +41,7 @@ with 0 spaces instead of 2"""
         xml_output_help = "Transcode jq JSON output back into XML and emit it"
         xml_dtd_help = "Preserve XML Document Type Definition (disables streaming of multiple docs)"
         xml_root_help = "When transcoding back to XML, envelope the output in an element with this name"
+        xml_force_list_help = "Tag name to pass to force_list parameter of xmltodict.parse(). Can be used multiple times."
     elif program_name == "tq":
         current_language = "TOML"
         toml_output_help = "Transcode jq JSON output back into TOML and emit it"
@@ -64,6 +66,7 @@ with 0 spaces instead of 2"""
                         help=xml_output_help)
     parser.add_argument("--xml-dtd", action="store_true", help=xml_dtd_help)
     parser.add_argument("--xml-root", help=xml_root_help)
+    parser.add_argument("--xml-force-list", dest="xml_force_list", action="append", help=xml_force_list_help)
     parser.add_argument("--toml-output", "-t", dest="output_format", action="store_const", const="toml",
                         help=toml_output_help)
     parser.add_argument("--in-place", "-i", action="store_true", help="Edit files in place (no backup - use caution)")


### PR DESCRIPTION
By default `xmltodict` does not return list in case only one element is present, which may lead to problems like this:

test.xml
```
<a>
<b/>
</a>
```

test1.xml
```
<a>
<b/>
<b/>
</a>
```

`xq . test.xml` produces
```
{
  "a": {
    "b": null
  }
}
```
while `xq . test1.xml` produces
```
{
  "a": {
    "b": [
      null,
      null
    ]
  }
}
```

The patch implements a new `--xml-force-list` switch, which allows forcing the use of arrays for defined tags even if only one occurence is present in the XML source:
```
xq --xml-force-list b . test.xml
{
  "a": {
    "b": [
      null
    ]
  }
}
```