### PR TITLE
Add support for input_format="json"

### DIFF
--- a/yq/__init__.py
+++ b/yq/__init__.py
@@ -167,6 +167,8 @@ def yq(input_streams=None, output_stream=None, input_format="yaml", output_forma
                 elif input_format == "toml":
                     import toml
                     input_docs.append(toml.load(input_stream))
+                elif input_format == "json":
+                    input_docs.append(json.load(input_stream))
                 else:
                     raise Exception("Unknown input format")
             input_payload = "\n".join(json.dumps(doc, cls=JSONDateTimeEncoder) for doc in input_docs)
@@ -221,6 +223,9 @@ def yq(input_streams=None, output_stream=None, input_format="yaml", output_forma
                 for input_stream in input_streams:
                     json.dump(toml.load(input_stream), jq.stdin)
                     jq.stdin.write("\n")
+            elif input_format == "json":
+                for input_stream in input_streams:
+                    print(input_stream.read(), file=jq.stdin)
             else:
                 raise Exception("Unknown input format")
 

--- a/yq/__init__.py
+++ b/yq/__init__.py
@@ -64,6 +64,8 @@ def cli(args=None, input_format="yaml", program_name="yq"):
     argcomplete.autocomplete(parser)
     args, jq_args = parser.parse_known_args(args=args)
 
+    args.input_format = args.input_format or input_format
+
     for i, arg in enumerate(jq_args):
         if arg.startswith("-") and not arg.startswith("--"):
             if "i" in arg:
@@ -110,7 +112,7 @@ def cli(args=None, input_format="yaml", program_name="yq"):
     elif not args.input_streams:
         args.input_streams = [sys.stdin]
 
-    yq_args = dict(input_format=input_format, program_name=program_name, jq_args=jq_args, **vars(args))
+    yq_args = dict(program_name=program_name, jq_args=jq_args, **vars(args))
     if in_place:
         if args.output_format not in {"yaml", "annotated_yaml"}:
             sys.exit("{}: -i/--in-place can only be used with -y/-Y".format(program_name))

--- a/yq/parser.py
+++ b/yq/parser.py
@@ -54,6 +54,7 @@ def get_parser(program_name, description):
     if sys.version_info >= (3, 5):
         parser_args.update(allow_abbrev=False)  # required to disambiguate options listed in jq_arg_spec
     parser = Parser(**parser_args)
+    parser.add_argument("--input-format", help=argparse.SUPPRESS)
     parser.add_argument("--output-format", default="json", help=argparse.SUPPRESS)
     parser.add_argument("--yaml-output", "--yml-output", "-y", dest="output_format", action="store_const", const="yaml",
                         help=yaml_output_help)
@@ -70,6 +71,7 @@ def get_parser(program_name, description):
     parser.add_argument("--xml-force-list", action="append", help=xml_force_list_help)
     parser.add_argument("--toml-output", "-t", dest="output_format", action="store_const", const="toml",
                         help=toml_output_help)
+    parser.add_argument("--json-input", "-j", dest="input_format", action="store_const", const="json")
     parser.add_argument("--in-place", "-i", action="store_true", help="Edit files in place (no backup - use caution)")
     parser.add_argument("--version", action="version", version="%(prog)s {version}".format(version=__version__))
 


### PR DESCRIPTION
This PR adds support for `yq.yq(input_format="json", output_format="toml")`.

In my case, I added this was because I wanted to turn a GitHub REST API response (json) into toml, and discovered there seems to be no way to parse json as input.

For me, it was super useful to be able to turn arbitrary json trees into toml files.

The tests seem to pass. If I missed anything, let me know.