### PR TITLE
Use tomllib/tomli/tomli-w instead of unmaintained toml package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,9 @@ the ``xq --xml-output``/``xq -x`` option. Multiple XML documents can be passed i
 TOML support
 ------------
 ``yq`` supports `TOML <https://toml.io/>`_ as well. The ``yq`` package installs an executable, ``tomlq``, which uses the
-`toml library <https://github.com/uiri/toml>`_ to transcode TOML to JSON, then pipes it to ``jq``. Roundtrip transcoding
+`tomllib module <https://docs.python.org/3.11/library/tomllib.html>` or `tomli library
+<https://github.com/hukkin/tomli>`_ to transcode TOML to JSON, then pipes it to ``jq``. Transcoding to TOML uses the
+`tomli-w <https://github.com/hukkin/toml-w`_ package. Roundtrip transcoding
 is available with the ``tomlq --toml-output``/``tomlq -t`` option.
 
 .. admonition:: Compatibility note

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(
     install_requires=[
         "PyYAML >= 5.3.1",
         "xmltodict >= 0.11.0",
-        "toml >= 0.10.0",
+        "tomli >= 1.2.3; python_version < '3.11'",
+        "tomli-w",
         "argcomplete >= 1.8.1"
     ],
     extras_require={


### PR DESCRIPTION
Replace the use of the unmaintained `toml` package with the modern trinity: built-in `tomllib` module for reading TOML in Python 3.11+, `tomli` for reading TOML in older Python versions and `tomli-w` for writing TOML in all Python versions.  This ensures correct TOML 1.0 support that the old `toml` package lacks.