### PR TITLE
Fix #152

### DIFF
--- a/yq/loader.py
+++ b/yq/loader.py
@@ -87,7 +87,7 @@ core_resolvers = {
         },
         {
             "tag": "tag:yaml.org,2002:int",
-            "regexp": re.compile(r"^(?:|0o[0-7]+|[-+]?(?:[0-9]+)|0x[0-9a-fA-F]+)$", re.X),
+            "regexp": re.compile(r"^(?:|0o[0-7]+|[-+]?(?:0|[1-9][0-9]*)|0x[0-9a-fA-F]+)$", re.X),
             "start_chars": list("-+0123456789"),
         },
         {


### PR DESCRIPTION
Not sure how to test it though, perhaps something like this?

```python
self.assertEqual(self.run_yq("0123456789", ["."]), "\"0123456789\"\n")
```

odd behaviour on pyyaml:

```
>>> import yaml
>>> yaml.safe_load("0123")
83
>>> yaml.safe_load("01239")
'01239'
```