### PR TITLE
feat: adding an option to control style of strings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,7 +110,7 @@ Forcing string styles using the ``-z`` (``--yaml-string_styles``) option
 The ``-z`` option will assume that strings might start with some style information.
 This option is only useful when using YAML-output (using ``-y`` or ``-Y``)
 
-To control the string style, the string itself has to be prepanded by additional information.
+To control the string style, the string itself has to be prepended by additional information.
 Valid control strings are:
 
 * ``__yq_style_'__``: uses single quotes ``'``
@@ -144,7 +144,7 @@ The usage can be simplified by adding the function ``style`` to ``~/.jq`` and/or
         end;
 
 
-This allows to simpify the above example to::
+This allows to simplify the above example to::
 
     yq -y -z '.field1 |= style("|")' input.yaml
 

--- a/yq/__init__.py
+++ b/yq/__init__.py
@@ -183,6 +183,7 @@ def yq(
     expand_aliases=True,
     max_expansion_factor=1024,
     yaml_output_grammar_version="1.1",
+    yaml_string_styles=False,
     jq_args=frozenset(),
     exit_func=None,
 ):
@@ -261,6 +262,7 @@ def yq(
                     use_annotations=use_annotations,
                     indentless=indentless_lists,
                     grammar_version=yaml_output_grammar_version,
+                    use_string_styles=yaml_string_styles
                 )
                 yaml.dump_all(
                     decode_docs(jq_out, json_decoder),

--- a/yq/parser.py
+++ b/yq/parser.py
@@ -100,6 +100,12 @@ def get_parser(program_name, description):
     parser.add_argument(
         "--yaml-output-grammar-version", "--yml-out-ver", choices=["1.1", "1.2"], default="1.1", help=grammar_help
     )
+    parser.add_argument(
+        "--yaml-string-styles",
+        "--yml-string-styles",
+        "-z",
+        action="store_true",
+        help="Allows special strings to control style of strings (only valid in combination with -y or -Y)")
     parser.add_argument("--width", "-w", type=int, help=width_help)
     parser.add_argument("--indentless-lists", "--indentless", action="store_true", help=indentless_help)
     parser.add_argument("--explicit-start", action="store_true", help=explicit_start_help)


### PR DESCRIPTION
Add options to control the styling of strings.

This capability is added by prepending a string with a specific control string (e.g. `__yq_style_|__`).
Because of this, this option is turned off by default and can be turned on by setting `--yaml-style-strings`.
