### PR TITLE
fix: Correction version number

### DIFF
--- a/yq/parser.py
+++ b/yq/parser.py
@@ -6,7 +6,7 @@ from typing import Union
 try:
     from .version import version as __version__
 except ImportError:
-    __version__ = "0.0.0"
+    __version__ = "3.4.3"
 
 # jq arguments that consume positionals must be listed here to avoid our parser mistaking them for our positionals
 jq_arg_spec = {


### PR DESCRIPTION
xq-python --version
0.0.0
yq --version
0.0.0

Why is the version result always 0.0.0?
The version should be consistent with the value in Changes.rst